### PR TITLE
按照deepin文件规范，修复可能导致安装成功找不到图标的问题

### DIFF
--- a/DebUOS/Packaging.DebUOS/DebUOSPackageFileStructCreator.cs
+++ b/DebUOS/Packaging.DebUOS/DebUOSPackageFileStructCreator.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -103,9 +104,9 @@ public class DebUOSPackageFileStructCreator
             // 这里不能使用 AppendLine 方法，保持换行使用 \n 字符
             stringBuilder
                 .Append("[Desktop Entry]\n")
-                .Append($"Categories={configuration.DesktopCategories}\n")
+                .Append($"Categories={string.Join(";", configuration.DesktopCategories.Split('\n'))};\n")
                 .Append($"Name={configuration.AppName}\n")
-                .Append($"Keywords={configuration.DesktopKeywords}\n")
+                .Append($"Keywords={string.Join(";", configuration.DesktopKeywords.Split('\n'))};\n")
                 .Append($"Comment={configuration.DesktopComment}\n")
                 .Append($"Type={configuration.DesktopType}\n")
                 .Append($"Terminal={configuration.DesktopTerminal.ToString().ToLowerInvariant()}\n")
@@ -118,7 +119,7 @@ public class DebUOSPackageFileStructCreator
 
             if (!string.IsNullOrEmpty(configuration.DesktopKeywordsZhCN))
             {
-                stringBuilder.Append($"Keywords[zh_CN]={configuration.DesktopKeywordsZhCN}\n");
+                stringBuilder.Append($"Keywords[zh_CN]={string.Join(";", configuration.DesktopKeywordsZhCN.Split('\n'))};\n");
             }
 
             if (!string.IsNullOrEmpty(configuration.DesktopCommentZhCN))
@@ -149,7 +150,7 @@ public class DebUOSPackageFileStructCreator
 
             if (!string.IsNullOrEmpty(configuration.DesktopMimeType))
             {
-                stringBuilder.Append($"MimeType={configuration.DesktopMimeType}\n");
+                stringBuilder.Append($"MimeType={string.Join(";", configuration.DesktopMimeType.Split('\n'))};\n");
             }
 
             File.WriteAllText(desktopFile, stringBuilder.ToString(), encoding);
@@ -222,7 +223,7 @@ public class DebUOSPackageFileStructCreator
                 Architecture = configuration.Architecture.Split(';')
             };
 
-            var permissions = infoPermissions?.Split(';');
+            var permissions = infoPermissions?.Split('\n');
             if (permissions != null && permissions.Length > 0)
             {
                 var applicationInfoPermissions = new ApplicationInfoPermissions();


### PR DESCRIPTION
1. 在deepin下，deb包安装成功后在桌面/启动器下找不到软件图标。按照[deepin官方wiki](https://wiki.deepin.org/zh/03_%E6%8A%80%E6%9C%AF%E8%A7%84%E8%8C%83/02_XDG%E8%A7%84%E8%8C%83/desktop%E6%96%87%E4%BB%B6%E8%A7%84%E8%8C%83) （搜索关键词string(s)），多值的键值对的项，应该用分号分隔，并且键的值可以选择用分号终止。尾随的空字符串必须始终以分号结尾。
2. InfoPermissions在解析coin文件时是`\n`为分割，修复InfoPermissions恒为false的问题