### PR TITLE
[DebUOS] 尝试给所有的 sh 文件加权限

### DIFF
--- a/CopyAfterCompileTool/CopyAfterCompileTool/BinaryChopCompiler.cs
+++ b/CopyAfterCompileTool/CopyAfterCompileTool/BinaryChopCompiler.cs
@@ -75,7 +75,7 @@ namespace dotnetCampus.CopyAfterCompileTool
 
             var git = new Git(codeDirectory)
             {
-                DefaultCommandTimeout = TimeSpan.FromMinutes(3)
+                //DefaultCommandTimeout = TimeSpan.FromMinutes(3)
             };
 
             _git = git;

--- a/DebUOS/Packaging.Targets/ArchiveBuilder.cs
+++ b/DebUOS/Packaging.Targets/ArchiveBuilder.cs
@@ -417,6 +417,20 @@ namespace Packaging.Targets
         /// </returns>
         private LinuxFileMode GetFileMode(string name, /*ITaskItem metadata, */LinuxFileMode defaultMode)
         {
+            // 后续可以尝试判断一下系统，在 Linux 下直接读取文件权限
+            //if (Environment.OSVersion.Platform == PlatformID.Unix)
+            //{
+            //}
+            //else
+            //{
+            // 在 Windows 下，直接给所有 sh 文件加权限
+            //}
+
+            if (Path.GetExtension(name) == ".sh")
+            {
+                return defaultMode | LinuxFileMode.S_IXOTH | LinuxFileMode.S_IXGRP | LinuxFileMode.S_IWUSR | LinuxFileMode.S_IXUSR;
+            }
+
             return defaultMode;
 
             //LinuxFileMode mode = defaultMode;


### PR DESCRIPTION
修复打包时 sh 文件无权限

在 Windows 下本来就不能读取，因此在 Windows 下这么写是正确的。但是在 Linux 下没有读取原本文件的权限，这是不对的