### PR TITLE
监听子文件夹变更

### DIFF
--- a/SyncTool/Server/SyncFolderManager.cs
+++ b/SyncTool/Server/SyncFolderManager.cs
@@ -31,9 +31,15 @@ class SyncFolderManager
         {
             EnableRaisingEvents = true,
             NotifyFilter = NotifyFilters.Size | NotifyFilters.CreationTime | NotifyFilters.DirectoryName |
-                           NotifyFilters.FileName | NotifyFilters.LastWrite
+                           NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.Attributes |
+                           NotifyFilters.LastAccess | NotifyFilters.Security,
+            IncludeSubdirectories = true,
         };
 
+        fileSystemWatcher.Error += (sender, args) =>
+        {
+            Console.WriteLine($"[SyncFolderManager] FileSystemWatcher Exception: {args.GetException()}");
+        };
         fileSystemWatcher.Changed += (sender, args) =>
         {
             UpdateChangeInner();


### PR DESCRIPTION
原本放在子文件夹的文件变更不会有任何触发，导致构建放在多层子文件夹的程序集同步失败