### PR TITLE
尝试修复加入的文件夹不符合预期

### DIFF
--- a/DebUOS/Packaging.DebUOS.Tool/Program.cs
+++ b/DebUOS/Packaging.DebUOS.Tool/Program.cs
@@ -39,7 +39,7 @@ else if (!string.IsNullOrEmpty(options.PackageArgumentFilePath))
     logger.LogInformation($"开始根据配置创建 UOS 的 deb 包。配置文件：{options.PackageArgumentFilePath}");
     if (!File.Exists(options.PackageArgumentFilePath))
     {
-        logger.LogError($"配置文件 '{options.PackageArgumentFilePath}' 不创建");
+        logger.LogError($"配置文件 '{options.PackageArgumentFilePath}' 不存在");
         return;
     }
 

--- a/DebUOS/Packaging.DebUOS/Contexts/Configurations/DebUOSConfiguration.cs
+++ b/DebUOS/Packaging.DebUOS/Contexts/Configurations/DebUOSConfiguration.cs
@@ -404,22 +404,25 @@ public class DebUOSConfiguration : Configuration
         set => SetValue(value);
         get => GetString();
     }
-    
+
     /// <summary>
     /// 配置是否将 opt\apps\${AppId}\entries\applications\${AppId}.desktop 文件 Copy 到 /usr/share/applications 文件夹里面。默认是 true 开启状态
-    /// Copy 到 /usr/share/applications 文件夹里面，是为了让应用在开始菜单里面显示，如果不需要在开始菜单里面显示，可以关闭此选项
+    /// Copy 到 /usr/share/applications 文件夹里面，是为了让应用在麒麟开始菜单里面显示，如果不需要在开始菜单里面显示，可以关闭此选项
     /// </summary>
+    /// <remarks>这是用于在麒麟系统里的，在统信 UOS 不需要这么做，但看起来在统信 UOS 做了也没问题</remarks>
     /// <example>true</example>
     public bool CopyDesktopFileToUsrShareApplications
     {
         set => SetValue(value);
         get => GetBoolean() ?? true;
     }
-    
+
     /// <summary>
     /// 配置是否将 opt\apps\${AppId}\entries\icons 文件夹 Copy 到 /usr/share/icons/hicolor 文件夹里面。默认是 true 开启状态
     /// Copy 到 /usr/share/icons/hicolor 文件夹里面，是为了让应用在开始菜单\桌面等地方能够正常显示图标，如果不需要显示图标，可以关闭此选项
     /// </summary>
+    /// <remarks>这是用于在麒麟系统里的，在统信 UOS 不需要这么做，但看起来在统信 UOS 做了也没问题</remarks>
+    /// <example>true</example>
     public bool CopyIconsToUsrShareIcons
     {
         set => SetValue(value);

--- a/DebUOS/Packaging.DebUOS/DebUOSPackageCreator.cs
+++ b/DebUOS/Packaging.DebUOS/DebUOSPackageCreator.cs
@@ -82,7 +82,7 @@ public class DebUOSPackageCreator
         Logger.LogInformation($"打包完成 '{outputDebFile.FullName}'");
     }
 
-    private readonly IReadOnlyList<string> _packageIncludeDirectories = new List<string> {"\\opt", "\\usr"};
+    private readonly IReadOnlyList<string> _packageIncludeDirectories = new [] {"\\opt", "\\usr"};
 
     private void WriteControl(DirectoryInfo packingFolder, Stream targetStream)
     {

--- a/DebUOS/Packaging.Targets/ArchiveBuilder.cs
+++ b/DebUOS/Packaging.Targets/ArchiveBuilder.cs
@@ -228,7 +228,7 @@ namespace Packaging.Targets
             return value;
         }
 
-        protected void AddDirectory(string directory, string relativePath, string prefix, List<ArchiveEntry> value/*, ITaskItem[] metadata*/, Predicate<string>? fileCanIncludePredicate)
+        public void AddDirectory(string directory, string relativePath, string prefix, List<ArchiveEntry> value/*, ITaskItem[] metadata*/, Predicate<string>? fileCanIncludePredicate)
         {
             this._inode++;
 


### PR DESCRIPTION
- 原先逻辑的 optFileCanIncludePredicate 传入空是表示通过，现在被改为不通过
- 从 `_packageIncludeDirectories` 获取的文件夹是使用 `\` 开头的，将导致在 Linux 平台执行不符合预期
- 每个文件都需要做一次判断，执行逻辑比较复杂

https://github.com/dotnet-campus/dotnetcampus.DotNETBuildSDK/pull/143