### PR TITLE
尝试修复日志内容在 Terminal Logger 模式被忽略

### DIFF
--- a/DebUOS/Packaging.DebUOS.Tool/Program.cs
+++ b/DebUOS/Packaging.DebUOS.Tool/Program.cs
@@ -107,7 +107,7 @@ class MSBuildFormatter : ConsoleFormatter
             LogLevel.Critical => "error: ",
             _ => "",
         };
-        textWriter.Write($"{logLevelString}{message}");
+        textWriter.Write($"{logLevelString}[DebUOS] {message}");
         if (exception != null)
         {
             textWriter.WriteLine(exception);


### PR DESCRIPTION
改之前，有警告信息也看不到，有错误信息也看不到，被智能(zz) 的 Terminal Logger 模式折叠忽略了：

![](https://github.com/user-attachments/assets/068967df-5377-46da-9e2e-8be43822187e)

改之后：

![](https://github.com/user-attachments/assets/4b7a70c7-9e8b-46df-9671-536a3abdbffe)

因为改之前只是简单控制台输出内容而已，没有按照 [如何在 MSBuild Target（Exec）中报告编译错误和编译警告 - walterlv](https://blog.walterlv.com/post/standard-error-warning-format ) 的格式输出为警告。在 Terminal Logger 被忽略