### PR TITLE
拆分出准备工作的任务，允许外部注入打包逻辑

### DIFF
--- a/DebUOS/Packaging.DebUOS.NuGet/Build/package.targets
+++ b/DebUOS/Packaging.DebUOS.NuGet/Build/package.targets
@@ -1,19 +1,19 @@
-<Project>
+﻿<Project>
 
-  <Target Name="AutoCreateDebUOS" AfterTargets="Publish" Condition="'$(AutoCreateDebUOSAfterPublish)' == 'true'" DependsOnTargets="CreateDebUOS">
+  <Target Name="AutoCreateDebUOS" AfterTargets="Publish" Condition="'$(AutoCreateDebUOSAfterPublish)' == 'true'"
+          DependsOnTargets="CreateDebUOS">
     <!-- 用来配置属性自动输出打包 -->
   </Target>
 
-  <Target Name="CreateDebUOS" DependsOnTargets="Publish">
-    <!-- 这里用 DependsOnTargets 原因是不要默认打包，只需要打包命令写 -t:CreateDebUOS 参数 -->
-    <!-- 如果期望默认发布时自动打出 UOS 的 deb 包，可以通过设置 AutoCreateDebUOSAfterPublish 属性为 true 的值，依靠 AutoCreateDebUOS 触发打包 -->
+  <Target Name="PrepareCreateDebUOS" BeforeTargets="CreateDebUOS">
+    <!-- 这是打包之前的准备工作 -->
     <PropertyGroup>
       <!-- 工作路径 -->
       <DebUOSPackingWorkFolder>$([MSBuild]::NormalizePath($(IntermediateOutputPath), 'DebUOSPacking'))</DebUOSPackingWorkFolder>
 
       <!-- 参数文件 -->
       <DebUOSPackingArgsFile>$([MSBuild]::NormalizePath($(DebUOSPackingWorkFolder), 'DebUOSPackingArgs.coin'))</DebUOSPackingArgsFile>
-      
+
       <!-- 默认参数 -->
       <AppName Condition="'$(AppName)' == ''">$(Product)</AppName>
       <DebControlDescription Condition="'$(DebControlDescription)' == ''">$(Description)</DebControlDescription>
@@ -25,292 +25,301 @@
     </PropertyGroup>
     <ItemGroup>
       <!-- COIN 格式的配置文件 https://github.com/dotnet-campus/dotnetCampus.Configurations -->
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="WorkingFolder"/>
-      <DebUOSPackingWriteArgLine Include="$(DebUOSPackingWorkFolder)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="ProjectPublishFolder"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(PublishDir)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="WorkingFolder" />
+      <DebUOSPackingWriteArgLine Include="$(DebUOSPackingWorkFolder)" />
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="ProjectPublishFolder" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(PublishDir)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
       <!-- 用来作为可执行文件的文件名 -->
-      <DebUOSPackingWriteArgLine Include="AssemblyName"/>
-      <DebUOSPackingWriteArgLine Include="$(AssemblyName)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include="AssemblyName" />
+      <DebUOSPackingWriteArgLine Include="$(AssemblyName)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
       <!-- 打包输出文件路径-->
-      <DebUOSPackingWriteArgLine Include="DebUOSOutputFilePath" Condition="$(DebUOSOutputFilePath)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(DebUOSOutputFilePath)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include="DebUOSOutputFilePath" Condition="$(DebUOSOutputFilePath)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(DebUOSOutputFilePath)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
       <!-- 获取平台，如 linux-x64 平台 -->
-      <DebUOSPackingWriteArgLine Include="RuntimeIdentifier" Condition="$(RuntimeIdentifier)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(RuntimeIdentifier)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include="RuntimeIdentifier" Condition="$(RuntimeIdentifier)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(RuntimeIdentifier)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebControlFile" Condition="$(DebControlFile)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(DebControlFile)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebControlFile" Condition="$(DebControlFile)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(DebControlFile)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebPostinstFile" Condition="$(DebPostinstFile)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(DebPostinstFile)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebPostinstFile" Condition="$(DebPostinstFile)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(DebPostinstFile)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebPrermFile" Condition="$(DebPrermFile)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(DebPrermFile)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebPrermFile" Condition="$(DebPrermFile)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(DebPrermFile)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebPostrmFile" Condition="$(DebPostrmFile)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(DebPostrmFile)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebPostrmFile" Condition="$(DebPostrmFile)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(DebPostrmFile)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebPreinstFile" Condition="$(DebPreinstFile)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(DebPreinstFile)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebPreinstFile" Condition="$(DebPreinstFile)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(DebPreinstFile)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebInfoFile" Condition="$(DebInfoFile)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(DebInfoFile)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebInfoFile" Condition="$(DebInfoFile)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(DebInfoFile)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebDesktopFile" Condition="$(DebDesktopFile)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(DebDesktopFile)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebDesktopFile" Condition="$(DebDesktopFile)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(DebDesktopFile)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="AppId" Condition="$(AppId)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(AppId)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="AppId" Condition="$(AppId)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(AppId)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="UOSAppId" Condition="$(UOSAppId)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(UOSAppId)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="UOSAppId" Condition="$(UOSAppId)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(UOSAppId)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="Version" Condition="$(Version)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(Version)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="Version" Condition="$(Version)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(Version)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="UOSDebVersion" Condition="$(UOSDebVersion)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(UOSDebVersion)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="UOSDebVersion" Condition="$(UOSDebVersion)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(UOSDebVersion)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebControlSection" Condition="$(DebControlSection)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlSection)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebControlSection" Condition="$(DebControlSection)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlSection)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebControlPriority" Condition="$(DebControlPriority)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(DebControlPriority)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebControlPriority" Condition="$(DebControlPriority)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(DebControlPriority)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="Architecture" Condition="$(Architecture)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(Architecture)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="Architecture" Condition="$(Architecture)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(Architecture)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebControlMultiArch" Condition="$(DebControlMultiArch)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlMultiArch)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebControlMultiArch" Condition="$(DebControlMultiArch)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlMultiArch)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebControlBuildDepends" Condition="$(DebControlBuildDepends)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlBuildDepends)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebControlBuildDepends" Condition="$(DebControlBuildDepends)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlBuildDepends)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebControlStandardsVersion" Condition="$(DebControlStandardsVersion)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(DebControlStandardsVersion)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebControlStandardsVersion" Condition="$(DebControlStandardsVersion)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(DebControlStandardsVersion)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebControlMaintainer" Condition="$(DebControlMaintainer)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlMaintainer)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebControlMaintainer" Condition="$(DebControlMaintainer)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlMaintainer)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebControlHomepage" Condition="$(DebControlHomepage)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlHomepage)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebControlHomepage" Condition="$(DebControlHomepage)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlHomepage)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebControlDescription" Condition="$(DebControlDescription)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlDescription)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebControlDescription" Condition="$(DebControlDescription)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlDescription)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebControlDepends" Condition="$(DebControlDepends)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlDepends)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebControlDepends" Condition="$(DebControlDepends)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlDepends)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DebControlXPackageSystem" Condition="$(DebControlXPackageSystem)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlXPackageSystem)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DebControlXPackageSystem" Condition="$(DebControlXPackageSystem)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DebControlXPackageSystem)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="AppName" Condition="$(AppName)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(AppName)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="AppName" Condition="$(AppName)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(AppName)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="InfoPermissions" Condition="$(InfoPermissions)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(InfoPermissions)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="InfoPermissions" Condition="$(InfoPermissions)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(InfoPermissions)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="AppNameZhCN" Condition="$(AppNameZhCN)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(AppNameZhCN)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="AppNameZhCN" Condition="$(AppNameZhCN)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(AppNameZhCN)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DesktopCategories" Condition="$(DesktopCategories)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopCategories)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DesktopCategories" Condition="$(DesktopCategories)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopCategories)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DesktopKeywords" Condition="$(DesktopKeywords)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopKeywords)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DesktopKeywords" Condition="$(DesktopKeywords)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopKeywords)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DesktopKeywordsZhCN" Condition="$(DesktopKeywordsZhCN)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopKeywordsZhCN)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DesktopKeywordsZhCN" Condition="$(DesktopKeywordsZhCN)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopKeywordsZhCN)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DesktopComment" Condition="$(DesktopComment)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopComment)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DesktopComment" Condition="$(DesktopComment)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopComment)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DesktopCommentZhCN" Condition="$(DesktopCommentZhCN)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopCommentZhCN)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DesktopCommentZhCN" Condition="$(DesktopCommentZhCN)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopCommentZhCN)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DesktopNoDisplay" Condition="$(DesktopNoDisplay)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopNoDisplay)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DesktopNoDisplay" Condition="$(DesktopNoDisplay)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopNoDisplay)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DesktopExec" Condition="$(DesktopExec)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(DesktopExec)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DesktopExec" Condition="$(DesktopExec)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(DesktopExec)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DesktopIcon" Condition="$(DesktopIcon)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(DesktopIcon)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DesktopIcon" Condition="$(DesktopIcon)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(DesktopIcon)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DesktopType" Condition="$(DesktopType)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopType)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DesktopType" Condition="$(DesktopType)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopType)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DesktopTerminal" Condition="$(DesktopTerminal)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(DesktopTerminal)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DesktopTerminal" Condition="$(DesktopTerminal)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(DesktopTerminal)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DesktopStartupNotify" Condition="$(DesktopStartupNotify)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(DesktopStartupNotify)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DesktopStartupNotify" Condition="$(DesktopStartupNotify)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(DesktopStartupNotify)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="DesktopMimeType" Condition="$(DesktopMimeType)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopMimeType)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="DesktopMimeType" Condition="$(DesktopMimeType)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(DesktopMimeType)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="CopyDesktopFileToUsrShareApplications" Condition="$(CopyDesktopFileToUsrShareApplications)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(CopyDesktopFileToUsrShareApplications)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="CopyDesktopFileToUsrShareApplications"
+                                 Condition="$(CopyDesktopFileToUsrShareApplications)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(CopyDesktopFileToUsrShareApplications)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="PackingFolder" Condition="$(PackingFolder)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(PackingFolder)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="PackingFolder" Condition="$(PackingFolder)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(PackingFolder)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="WorkingFolder" Condition="$(WorkingFolder)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(WorkingFolder)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="WorkingFolder" Condition="$(WorkingFolder)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(WorkingFolder)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="ProjectPublishFolder" Condition="$(ProjectPublishFolder)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(ProjectPublishFolder)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="ProjectPublishFolder" Condition="$(ProjectPublishFolder)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(ProjectPublishFolder)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="UOSDebIconFolder" Condition="$(UOSDebIconFolder)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(UOSDebIconFolder)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="UOSDebIconFolder" Condition="$(UOSDebIconFolder)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(UOSDebIconFolder)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="SvgIconFile" Condition="$(SvgIconFile)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(SvgIconFile)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="SvgIconFile" Condition="$(SvgIconFile)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(SvgIconFile)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="Png16x16IconFile" Condition="$(Png16x16IconFile)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(Png16x16IconFile)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="Png16x16IconFile" Condition="$(Png16x16IconFile)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(Png16x16IconFile)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="Png24x24IconFile" Condition="$(Png24x24IconFile)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(Png24x24IconFile)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="Png24x24IconFile" Condition="$(Png24x24IconFile)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(Png24x24IconFile)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="Png32x32IconFile" Condition="$(Png32x32IconFile)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(Png32x32IconFile)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="Png32x32IconFile" Condition="$(Png32x32IconFile)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(Png32x32IconFile)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="Png48x48IconFile" Condition="$(Png48x48IconFile)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(Png48x48IconFile)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="Png48x48IconFile" Condition="$(Png48x48IconFile)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(Png48x48IconFile)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="Png128x128IconFile" Condition="$(Png128x128IconFile)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(Png128x128IconFile)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="Png128x128IconFile" Condition="$(Png128x128IconFile)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(Png128x128IconFile)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="Png256x256IconFile" Condition="$(Png256x256IconFile)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(Png256x256IconFile)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="Png256x256IconFile" Condition="$(Png256x256IconFile)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(Png256x256IconFile)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="Png512x512IconFile" Condition="$(Png512x512IconFile)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$(Png512x512IconFile)"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="Png512x512IconFile" Condition="$(Png512x512IconFile)!=''" />
+      <DebUOSPackingWriteArgLine Include="$(Png512x512IconFile)" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="ExcludePackingDebFileExtensions" Condition="$(ExcludePackingDebFileExtensions)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(ExcludePackingDebFileExtensions)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="ExcludePackingDebFileExtensions"
+                                 Condition="$(ExcludePackingDebFileExtensions)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(ExcludePackingDebFileExtensions)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
-      <DebUOSPackingWriteArgLine Include=">"/>
-      <DebUOSPackingWriteArgLine Include="UsingAppVersionInsteadOfBinOnDebPacking" Condition="$(UsingAppVersionInsteadOfBinOnDebPacking)!=''"/>
-      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(UsingAppVersionInsteadOfBinOnDebPacking)))"/>
-      <DebUOSPackingWriteArgLine Include=">"/>
+      <DebUOSPackingWriteArgLine Include=">" />
+      <DebUOSPackingWriteArgLine Include="UsingAppVersionInsteadOfBinOnDebPacking"
+                                 Condition="$(UsingAppVersionInsteadOfBinOnDebPacking)!=''" />
+      <DebUOSPackingWriteArgLine Include="$([MSBuild]::Escape($(UsingAppVersionInsteadOfBinOnDebPacking)))" />
+      <DebUOSPackingWriteArgLine Include=">" />
 
     </ItemGroup>
     <WriteLinesToFile File="$(DebUOSPackingArgsFile)" Lines="@(DebUOSPackingWriteArgLine)" Overwrite="True" />
-    <Exec Command="dotnet &quot;$(MSBuildThisFileDirectory)..\tools\Packaging.DebUOS.Tool.dll&quot; -p $(DebUOSPackingArgsFile)" />
+  </Target>
+
+  <Target Name="CreateDebUOS" DependsOnTargets="Publish">
+    <!-- 这里用 DependsOnTargets 原因是不要默认打包，只需要打包命令写 -t:CreateDebUOS 参数 -->
+    <!-- 如果期望默认发布时自动打出 UOS 的 deb 包，可以通过设置 AutoCreateDebUOSAfterPublish 属性为 true 的值，依靠 AutoCreateDebUOS 触发打包 -->
+    <Exec
+      Command="dotnet &quot;$(MSBuildThisFileDirectory)..\tools\Packaging.DebUOS.Tool.dll&quot; -p $(DebUOSPackingArgsFile)" />
   </Target>
 </Project>


### PR DESCRIPTION
故事背景：

为了拷贝 dotnet 运行时，需要将 deb 包的制作分为两个步骤，一个是准备，第二个是打包。如此才可以在准备之后，拷贝 dotnet 运行时，然后再执行打包

为什么需要拷贝 dotnet 运行时，是为了使用 AppHostRelativeDotNet 指定自定义的运行时路径。详细请看 [dotnet 9 通过 AppHostRelativeDotNet 指定自定义的运行时路径](https://blog.lindexi.com/post/dotnet-9-%E9%80%9A%E8%BF%87-AppHostRelativeDotNet-%E6%8C%87%E5%AE%9A%E8%87%AA%E5%AE%9A%E4%B9%89%E7%9A%84%E8%BF%90%E8%A1%8C%E6%97%B6%E8%B7%AF%E5%BE%84.html )