### PR TITLE
Revert: Linux Control 文件删掉最后的空行

### DIFF
--- a/DebUOS/Packaging.DebUOS/DebUOSPackageFileStructCreator.cs
+++ b/DebUOS/Packaging.DebUOS/DebUOSPackageFileStructCreator.cs
@@ -381,11 +381,6 @@ public class DebUOSPackageFileStructCreator
                 stringBuilder.Append($"X-Package-System: {configuration.DebControlXPackageSystem}\n");
             }
 
-            // 去掉最后的空行
-            if (stringBuilder[^1] == '\n')
-            {
-                stringBuilder.Remove(stringBuilder.Length - 1, 1);
-            }
             File.WriteAllText(controlFile, stringBuilder.ToString(), encoding);
         }
 


### PR DESCRIPTION
Revert https://github.com/dotnet-campus/dotnetcampus.DotNETBuildSDK/pull/173

删除空行导致在某些设备安装失败，提示包含 EOF 错误

原本删除空行是为了让 EU 能直接追加，但不符合规范